### PR TITLE
Add Ableton 12 theme editor prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 Ableton 12 Theme Creator – GUI Editor & Smart Theme Engine
+===========================================================
 
-A tool that mimics Ableton 12’s Arrange view, allowing real-time visual theme editing using pre-extracted UI assets, with smart theme generation via images, screenshots, or text prompts.
+This project provides a basic web-based prototype for editing Ableton 12 themes.
+It mimics the Arrange view with three regions (header, arrange area, and footer).
+Hover a region to highlight it. Clicking opens a palette where you can adjust
+colour and brightness. Theme settings can be imported/exported as JSON.
+
+Quick start
+-----------
+1. Open `src/index.html` in a browser.
+2. Click on any region to edit its colour.
+3. Use the toolbar to import/export theme files or generate a palette from an
+   image.
+
+Theme file format
+-----------------
+`theme.json` looks like this:
+```json
+{
+  "header": "#2b2b2b",
+  "arrange": "#444444",
+  "footer": "#2b2b2b"
+}
+```
+
+Limitations
+-----------
+This demo does not include official Ableton assets. It offers a simplified
+workflow that can be expanded with real screenshots or UI elements.

--- a/src/app.js
+++ b/src/app.js
@@ -44,11 +44,15 @@ exportBtn.addEventListener('click',()=>{
 });
 themeFile.addEventListener('change',e=>{
  const file=e.target.files[0];
- if(!file)return;
+ if(!file){
+   themeFile.value = '';
+   return;
+ }
  const reader=new FileReader();
  reader.onload=()=>{
    try{theme=JSON.parse(reader.result);applyTheme();}
    catch(err){alert('Invalid theme file');}
+   themeFile.value = '';
  };
  reader.readAsText(file);
 });

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,97 @@
+const regions=document.querySelectorAll('.ui-region');
+const palette=document.getElementById('palette');
+const colorPicker=document.getElementById('colorPicker');
+const brightness=document.getElementById('brightness');
+const applyBtn=document.getElementById('apply');
+const importBtn=document.getElementById('importBtn');
+const exportBtn=document.getElementById('exportBtn');
+const imagePaletteBtn=document.getElementById('imagePaletteBtn');
+const undoBtn=document.getElementById('undoBtn');
+const resetBtn=document.getElementById('resetBtn');
+const themeFile=document.getElementById('themeFile');
+const imageFile=document.getElementById('imageFile');
+let currentRegion=null;
+let theme={header:'#2b2b2b',arrange:'#444',footer:'#2b2b2b'};
+let history=[];
+function applyTheme(){
+ document.getElementById('header').style.background=theme.header;
+ document.getElementById('arrange').style.background=theme.arrange;
+ document.getElementById('footer').style.background=theme.footer;
+}
+regions.forEach(r=>{
+ r.addEventListener('mouseenter',()=>r.classList.add('hover'));
+ r.addEventListener('mouseleave',()=>r.classList.remove('hover'));
+ r.addEventListener('click',()=>{
+   currentRegion=r.id;
+   colorPicker.value=rgb2hex(window.getComputedStyle(r).backgroundColor);
+   palette.classList.remove('hidden');
+ });
+});
+applyBtn.addEventListener('click',()=>{
+ if(!currentRegion) return;
+ history.push(JSON.stringify(theme));
+ theme[currentRegion]=adjustBrightness(colorPicker.value,parseFloat(brightness.value));
+ applyTheme();
+});
+importBtn.addEventListener('click',()=>themeFile.click());
+exportBtn.addEventListener('click',()=>{
+ const data=JSON.stringify(theme, null, 2);
+ const blob=new Blob([data],{type:'application/json'});
+ const a=document.createElement('a');
+ a.href=URL.createObjectURL(blob);
+ a.download='theme.json';
+ a.click();
+});
+themeFile.addEventListener('change',e=>{
+ const file=e.target.files[0];
+ if(!file)return;
+ const reader=new FileReader();
+ reader.onload=()=>{
+   try{theme=JSON.parse(reader.result);applyTheme();}
+   catch(err){alert('Invalid theme file');}
+ };
+ reader.readAsText(file);
+});
+imagePaletteBtn.addEventListener('click',()=>imageFile.click());
+imageFile.addEventListener('change',e=>{
+ const file=e.target.files[0];
+ if(!file)return;
+ const img=new Image();
+ const reader=new FileReader();
+ reader.onload=()=>{img.src=reader.result;};
+ reader.readAsDataURL(file);
+ img.onload=()=>{
+   const canvas=document.createElement('canvas');
+   canvas.width=img.width;canvas.height=img.height;
+   const ctx=canvas.getContext('2d');
+   ctx.drawImage(img,0,0);
+   const data=ctx.getImageData(0,0,canvas.width,canvas.height).data;
+   let r=0,g=0,b=0,count=0;
+   for(let i=0;i<data.length;i+=4){r+=data[i];g+=data[i+1];b+=data[i+2];count++;}
+   r=Math.round(r/count);g=Math.round(g/count);b=Math.round(b/count);
+   colorPicker.value=rgb2hex(`rgb(${r},${g},${b})`);
+ };
+});
+undoBtn.addEventListener('click',()=>{
+ const prev=history.pop();
+ if(prev){theme=JSON.parse(prev);applyTheme();}
+});
+resetBtn.addEventListener('click',()=>{
+ theme={header:'#2b2b2b',arrange:'#444',footer:'#2b2b2b'};
+ applyTheme();
+});
+function rgb2hex(rgb){
+ const result=/rgb\((\d+),\s*(\d+),\s*(\d+)\)/.exec(rgb);
+ if(!result)return '#000000';
+ return'#'+[1,2,3].map(i=>('0'+parseInt(result[i]).toString(16)).slice(-2)).join('');
+}
+function adjustBrightness(hex,scale){
+ let r=parseInt(hex.substr(1,2),16);
+ let g=parseInt(hex.substr(3,2),16);
+ let b=parseInt(hex.substr(5,2),16);
+ r=Math.min(255,Math.max(0,Math.round(r*scale)));
+ g=Math.min(255,Math.max(0,Math.round(g*scale)));
+ b=Math.min(255,Math.max(0,Math.round(b*scale)));
+ return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+}
+applyTheme();

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Ableton 12 Theme Creator</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div id="app">
+  <div id="header" class="ui-region">Header</div>
+  <div id="arrange" class="ui-region">Arrange View</div>
+  <div id="footer" class="ui-region">Footer</div>
+</div>
+<div id="palette" class="hidden">
+  <label>Color<input type="color" id="colorPicker"></label>
+  <label>Brightness<input type="range" id="brightness" min="0" max="2" step="0.1" value="1"></label>
+  <button id="apply">Apply</button>
+</div>
+<input type="file" id="themeFile" accept="application/json" class="hidden" />
+<input type="file" id="imageFile" accept="image/*" class="hidden" />
+<div id="toolbar">
+  <button id="importBtn">Import Theme</button>
+  <button id="exportBtn">Export Theme</button>
+  <button id="imagePaletteBtn">Image Palette</button>
+  <button id="undoBtn">Undo</button>
+  <button id="resetBtn">Restore Defaults</button>
+</div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,38 @@
+body,html{
+  margin:0;
+  padding:0;
+  height:100%;
+  font-family:sans-serif;
+  background:#111;
+  color:#eee;
+}
+#app{
+  display:flex;
+  flex-direction:column;
+  height:100%;
+}
+.ui-region{
+  flex:1;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  border:1px solid #333;
+  position:relative;
+}
+#header{background:#2b2b2b;height:50px;flex:none;}
+#footer{background:#2b2b2b;height:80px;flex:none;}
+#arrange{background:#444;flex:1;}
+.ui-region.hover{
+  box-shadow:0 0 10px #fff;
+}
+#palette{
+  position:fixed;
+  top:10px;right:10px;
+  background:#222;
+  padding:10px;
+  border:1px solid #555;
+}
+.hidden{display:none;}
+#toolbar{
+  position:fixed;bottom:10px;left:10px;
+}


### PR DESCRIPTION
## Summary
- build `src/` with HTML/CSS/JS for a simple Ableton Arrange view mock‑up
- allow changing colours via a palette, with import/export and image palette
- document usage and theme format in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fc2d06f108331bcb8f6c88ef4666e

## Summary by Sourcery

Provide a basic web-based Ableton 12 theme editor prototype featuring interactive region coloring, JSON import/export, image-based palette generation, and undo/reset functionality

New Features:
- Add interactive mock Arrange view with header, arrange area, and footer regions for live theme editing
- Enable per-region color and brightness adjustments through a palette UI
- Support importing and exporting theme configurations as JSON files
- Allow generating theme palettes by extracting average color from uploaded images
- Implement undo and reset-to-default actions for theme changes

Documentation:
- Update README with project overview, quick start guide, theme file format, and known limitations